### PR TITLE
Do not ask for token when vendor is ollama because it's not used

### DIFF
--- a/internal/ai/ollama.go
+++ b/internal/ai/ollama.go
@@ -35,10 +35,6 @@ type ollama struct {
 
 // Ask sends a question to the AI and returns the answer.
 func (ai ollama) Ask(history []string) (string, error) {
-	if ai.config.Token == "" {
-		return "", errMissingToken
-	}
-
 	messages := buildMessages(ai.config.Prompt, history)
 	req, err := ai.buildReq(messages)
 	if err != nil {

--- a/internal/ai/ollama_test.go
+++ b/internal/ai/ollama_test.go
@@ -1,0 +1,39 @@
+package ai
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestOllama_Ask(t *testing.T) {
+	config := Config{
+		Vendor: "ollama",
+		// We don't need token for olama
+		Token:       "",
+		Model:       "qwen2.5-coder:1.5b",
+		Prompt:      "You are a test assistant.",
+		Temperature: 0.7,
+		Timeout:     30 * time.Second,
+	}
+	ai := ollama{config}
+
+	t.Run("successful response", func(t *testing.T) {
+		httpClient = NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString(`{"choices": [{"message": {"content": "test"}}]}`)),
+				Header:     make(http.Header),
+			}
+		})
+
+		history := []string{}
+
+		_, err := ai.Ask(history)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/ai/ollama_test.go
+++ b/internal/ai/ollama_test.go
@@ -18,22 +18,25 @@ func TestOllama_Ask(t *testing.T) {
 		Temperature: 0.7,
 		Timeout:     30 * time.Second,
 	}
-	ai := ollama{config}
+	history := []string{"Hello", "Hi there!"}
 
 	t.Run("successful response", func(t *testing.T) {
 		httpClient = NewTestClient(func(req *http.Request) *http.Response {
 			return &http.Response{
 				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewBufferString(`{"choices": [{"message": {"content": "test"}}]}`)),
+				Body:       io.NopCloser(bytes.NewBufferString(`{"message": {"content": "I'm doing great!"}}`)),
 				Header:     make(http.Header),
 			}
 		})
 
-		history := []string{}
+		ai := ollama{config}
 
-		_, err := ai.Ask(history)
+		answer, err := ai.Ask(history)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
+		}
+		if answer != "I'm doing great!" {
+			t.Errorf("Expected answer: I'm doing great!, got: %s", answer)
 		}
 	})
 }


### PR DESCRIPTION
The token from the config is not used when vendor is `ollama`.

Before the change:
```
% go run ./ delete filesystem from the root
ERROR: Set HOWTO_AI_TOKEN to your AI vendor API key.
See https://github.com/nalgeon/howto#readme for details
exit status 1
```

After the change:
```
% go run ./ delete filesystem from the root
rm -rf /

Explanation:
- `rm` is used to remove files and directories.
- `-r` stands for recursive, which means it will delete all contents within the
directory as well.
- `-f` stands for force, which means it will not prompt for confirmation before
deleting files.

This command will delete everything in the root directory, including all
subdirectories and files. Be very careful when using this command, as it cannot
be undone.
```